### PR TITLE
Add MySQL SQL mode getter/setter

### DIFF
--- a/lib/Doctrine/Connection/Mysql.php
+++ b/lib/Doctrine/Connection/Mysql.php
@@ -128,6 +128,27 @@ class Doctrine_Connection_Mysql extends Doctrine_Connection_Common
     }
 
     /**
+     * Get the SQL mode on the current connection
+     */
+    public function getSqlMode()
+    {
+        return $this->fetchOne('SELECT @@sql_mode');
+    }
+
+    /**
+     * Set the SQL mode on the current connection
+     *
+     * @param string $sqlmode   SQL mode
+     *
+     * @link http://dev.mysql.com/doc/refman/5.7/en/server-options.html#option_mysqld_sql-mode
+     */
+    public function setSqlMode($sqlmode)
+    {
+        $query = 'SET sql_mode = ' . $this->quote($sqlmode);
+        $this->exec($query);
+    }
+
+    /**
      * Execute a SQL REPLACE query. A REPLACE query is identical to a INSERT
      * query, except that if there is already a row in the table with the same
      * key field values, the REPLACE query just updates its values instead of


### PR DESCRIPTION
This patch add getter/setter for MySQL SQL mode.
MySQL 5.7 GA release (5.7.9) change the default SQL mode from `NO_ENGINE_SUBSTITUTION` to `ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION` breaking some legacy applications: thanks to these methods sql_mode can be changed on the fly with Doctrine
